### PR TITLE
Read SSE stream correctly

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.3
 require (
 	github.com/google/uuid v1.6.0
 	github.com/qri-io/jsonschema v0.2.1
+	github.com/tmaxmax/go-sse v0.10.0
 )
 
 require github.com/qri-io/jsonpointer v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,3 +10,5 @@ github.com/sergi/go-diff v1.0.0 h1:Kpca3qRNrduNnOQeazBd0ysaKrUJiIuISHxogkT9RPQ=
 github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAmXWZgo=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
+github.com/tmaxmax/go-sse v0.10.0 h1:j9F93WB4Hxt8wUf6oGffMm4dutALvUPoDDxfuDQOSqA=
+github.com/tmaxmax/go-sse v0.10.0/go.mod h1:u/2kZQR1tyngo1lKaNCj1mJmhXGZWS1Zs5yiSOD+Eg8=

--- a/pkg/mcp/sse.go
+++ b/pkg/mcp/sse.go
@@ -1,7 +1,6 @@
 package mcp
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
@@ -10,10 +9,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 	"sync"
 
 	"github.com/google/uuid"
+	"github.com/tmaxmax/go-sse"
 )
 
 // SSEServer implements a Server-Sent Events (SSE) server that manages client connections
@@ -295,36 +294,12 @@ func (s *SSEClient) StartSession() (string, error) {
 		return "", fmt.Errorf("unexpected status code: %d", resp.StatusCode)
 	}
 
-	// Read the first SSE event which contains the message URL
-	scanner := bufio.NewScanner(resp.Body)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if strings.HasPrefix(line, "endpoint: ") {
-			s.messageURL = strings.TrimSpace(strings.TrimPrefix(line, "endpoint: "))
-			break
-		}
-	}
-	if s.messageURL == "" {
-		resp.Body.Close()
-		return "", fmt.Errorf("failed to read message URL from SSE event")
-	}
+	session := make(chan sessionResponse)
 
-	// Parse the session ID from the message URL
-	parsedURL, err := url.Parse(s.messageURL)
-	if err != nil {
-		resp.Body.Close()
-		return "", fmt.Errorf("invalid message URL: %w", err)
-	}
+	go s.listenMessages(resp.Body, session)
 
-	sessID := parsedURL.Query().Get("sessionID")
-	if sessID == "" {
-		resp.Body.Close()
-		return "", fmt.Errorf("no session ID in message URL")
-	}
-
-	go s.listenMessages(sessID, resp.Body)
-
-	return sessID, nil
+	sessionResp := <-session
+	return sessionResp.sessionID, sessionResp.err
 }
 
 // SessionMessages returns a receive-only channel that provides incoming messages
@@ -350,48 +325,79 @@ func (s *SSEClient) Close() {
 	close(s.closeChan)
 }
 
-func (s *SSEClient) listenMessages(sessID string, body io.ReadCloser) {
-	defer body.Close()
+type sessionResponse struct {
+	sessionID string
+	err       error
+}
 
-	scanner := bufio.NewScanner(body)
-	for scanner.Scan() {
+func (s *SSEClient) listenMessages(body io.ReadCloser, session chan<- sessionResponse) {
+	defer body.Close()
+	defer close(session)
+
+	var sessID string
+
+	for ev, err := range sse.Read(body, nil) {
 		select {
 		case <-s.closeChan:
+			if sessID == "" {
+				session <- sessionResponse{err: fmt.Errorf("failed to initialize session: client closed")}
+			}
 			return
 		default:
 		}
 
-		line := scanner.Text()
-		if line == "" {
-			// Skip empty lines
-			continue
-		}
-		var input string
-		if strings.HasPrefix(line, "message: ") {
-			input = strings.TrimSpace(strings.TrimPrefix(line, "message: "))
-		}
-
-		var msg JSONRPCMessage
-		if err := json.Unmarshal([]byte(input), &msg); err != nil {
-			s.logError(fmt.Errorf("failed to unmarshal message: %w", err))
-			continue
+		if err != nil {
+			if !errors.Is(err, context.Canceled) {
+				s.logError(fmt.Errorf("failed to read SSE events: %w", err))
+			}
+			if sessID == "" {
+				session <- sessionResponse{err: fmt.Errorf("failed to initialize session: %w", err)}
+			}
+			return
 		}
 
-		errs := make(chan error)
-		s.messagesChan <- SessionMsgWithErrs{
-			SessionID: sessID,
-			Msg:       msg,
-			Errs:      errs,
-		}
+		switch ev.Type {
+		case "endpoint":
+			if sessID != "" {
+				continue
+			}
 
-		if err := <-errs; err != nil {
-			s.logError(fmt.Errorf("failed to handle message: %w", err))
-		}
-	}
+			u, err := url.Parse(ev.Data)
+			if err != nil {
+				session <- sessionResponse{err: fmt.Errorf("parse endpoint URL: %w", err)}
+				return
+			}
 
-	if scanner.Err() != nil {
-		if !errors.Is(scanner.Err(), context.Canceled) {
-			s.logError(fmt.Errorf("failed to read SSE events: %w", scanner.Err()))
+			sessID = u.Query().Get("sessionID")
+			if sessID == "" {
+				session <- sessionResponse{err: fmt.Errorf("no session ID in message URL")}
+			} else {
+				session <- sessionResponse{sessionID: sessID}
+			}
+		case "message":
+			if sessID == "" {
+				s.logError(fmt.Errorf("received message before endpoint URL"))
+				return
+			}
+
+			var msg JSONRPCMessage
+			if err := json.Unmarshal([]byte(ev.Data), &msg); err != nil {
+				s.logError(fmt.Errorf("failed to unmarshal message: %w", err))
+				continue
+			}
+
+			errs := make(chan error)
+			s.messagesChan <- SessionMsgWithErrs{
+				SessionID: sessID,
+				Msg:       msg,
+				Errs:      errs,
+			}
+
+			if err := <-errs; err != nil {
+				s.logError(fmt.Errorf("failed to handle message: %w", err))
+			}
+		default:
+			s.logError(fmt.Errorf("unhandled event type %q", ev.Type))
 		}
 	}
 }

--- a/pkg/mcp/sse.go
+++ b/pkg/mcp/sse.go
@@ -97,7 +97,7 @@ func (s SSEServer) Send(ctx context.Context, msg SessionMsg) error {
 	errs := make(chan error)
 
 	go func() {
-		_, err = fmt.Fprintf(wr, "message: %s\n\n", msgBs)
+		_, err = fmt.Fprintf(wr, "event: message\ndata: %s\n\n", msgBs)
 		if err != nil {
 			errs <- fmt.Errorf("failed to write message: %w", err)
 			return
@@ -164,7 +164,7 @@ func (s SSEServer) HandleSSE(messageBaseURL string) http.Handler {
 		s.writers.Store(sessID, w)
 
 		url := fmt.Sprintf("%s?sessionID=%s", messageBaseURL, sessID)
-		_, err := fmt.Fprintf(w, "endpoint: %s\n\n", url)
+		_, err := fmt.Fprintf(w, "event: endpoint\ndata: %s\n\n", url)
 		if err != nil {
 			nErr := fmt.Errorf("failed to write SSE URL: %w", err)
 			http.Error(w, nErr.Error(), http.StatusInternalServerError)
@@ -367,6 +367,7 @@ func (s *SSEClient) listenMessages(body io.ReadCloser, session chan<- sessionRes
 				session <- sessionResponse{err: fmt.Errorf("parse endpoint URL: %w", err)}
 				return
 			}
+			s.messageURL = u.String()
 
 			sessID = u.Query().Get("sessionID")
 			if sessID == "" {


### PR DESCRIPTION
There was a subtle bug in the code for which I had to restructure the session ID retrieval code a bit unconfortably – `bufio.Scanner` might read more from the input `io.Reader` than `.Text()` returns, which means that initializing a second `bufio.Scanner` from the same input reader (or, really, just reading further from that reader in general) can result in losing data. The way to fix this is to use the same `bufio.Scanner` to parse the entire stream. [From the documentation:](https://pkg.go.dev/bufio#Scanner)

> When a scan stops, the reader may have advanced arbitrarily far past the last token.

Anyway, I've used my own library to implement this – namely the new [`sse.Read`](https://pkg.go.dev/github.com/tmaxmax/go-sse#Read) function. For me personally it wasn't worth reimplementing server-sent events parsing – if you wish to do that (as a learning experience or for less dependencies), feel free to rewrite this yourself.

Lastly, as a general impression, I have a feeling that the way the `Transport` interface is designed leads to the contrived code inside `StartSession`. It might be worth to explore other designs. As a possible starting point for improvement, in general the caller, not the callee should manage concurrency – i.e., the caller should spawn goroutines, create channels etc. I'm not able to find a reference for this principle at the moment (I'll drop a link if I come again by one) but it's well known advice around the community. The `Transport` interface – or at least the way the SSE transport is implemented – does not allow this at the moment. A change in this direction may have a chance to improve the code. I haven't familiarized myself with the design here so I can't tell for sure what needs to be done, this is just an intuition.

Let me know if you want me to make any other changes to this PR.